### PR TITLE
Create shrinkgpw.py

### DIFF
--- a/shrinkgpw.py
+++ b/shrinkgpw.py
@@ -6,7 +6,6 @@ shrinkgpw.py: Extracting wave functions from gpw file to get smaller files
 Usage: $ shrinkgpw.py <file.gpw>
 '''
 from ase import *
-from ase.io import read
 from gpaw import GPAW
 import sys, os
 from pathlib import Path

--- a/shrinkgpw.py
+++ b/shrinkgpw.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+ 
+'''
+shrinkgpw.py: Extracting wave functions from gpw file to get smaller files
+
+Usage: $ shrinkgpw.py <file.gpw>
+'''
+from ase import *
+from ase.io import read
+from gpaw import GPAW
+import sys, os
+from pathlib import Path
+
+if len(sys.argv) > 1:
+    inFile = os.path.join(os.getcwd(),sys.argv[1])
+else:
+    print("Please provide a GPW file to continue.")
+    exit()
+
+calc = GPAW(inFile)
+
+# Writing result
+calc.write(os.path.join(os.getcwd(),Path(inFile).stem+'_withoutwf.gpw'))


### PR DESCRIPTION
A new command to shrink huge GPW files by extracting wavefunction information. By default, `gpawsolve.py` uses `all` mode when saving gpw files in Electron density calculations. However, it may be unnecessary after the calculation is finished. This small command can be used to shrink GPW files.